### PR TITLE
Fix deprecated wfGetLB()

### DIFF
--- a/maintenance/importEntities.php
+++ b/maintenance/importEntities.php
@@ -125,7 +125,7 @@ class ImportEntities extends \Maintenance {
 	private function newEntityImporter() {
 		$entityImporterFactory = new EntityImporterFactory(
 			WikibaseRepo::getStore()->getEntityStore(),
-			MediaWikiServices::getDBLoadBalancer(),
+			MediaWikiServices::getInstance()->getDBLoadBalancer(),
 			$this->logger,
 			$this->getConfig()->get( 'WBImportSourceApi' )
 		);

--- a/maintenance/importEntities.php
+++ b/maintenance/importEntities.php
@@ -13,6 +13,7 @@ use Wikibase\Import\LoggerFactory;
 use Wikibase\Import\QueryRunner;
 use Wikibase\Import\PropertyIdLister;
 use Wikibase\Repo\WikibaseRepo;
+use MediaWiki\MediaWikiServices;
 
 $IP = getenv( 'MW_INSTALL_PATH' );
 if ( $IP === false ) {

--- a/maintenance/importEntities.php
+++ b/maintenance/importEntities.php
@@ -124,7 +124,7 @@ class ImportEntities extends \Maintenance {
 	private function newEntityImporter() {
 		$entityImporterFactory = new EntityImporterFactory(
 			WikibaseRepo::getStore()->getEntityStore(),
-			wfGetLB(),
+			MediaWikiServices::getDBLoadBalancer(),
 			$this->logger,
 			$this->getConfig()->get( 'WBImportSourceApi' )
 		);

--- a/tests/integration/ApiEntityLookupIntegrationTest.php
+++ b/tests/integration/ApiEntityLookupIntegrationTest.php
@@ -36,7 +36,7 @@ class ApiEntityLookupIntegrationTest extends \PHPUnit_Framework_TestCase {
 	private function getApiEntityLookup() {
 		$entityImporterFactory = new EntityImporterFactory(
 			WikibaseRepo::getDefaultInstance()->getStore()->getEntityStore(),
-			wfGetLB(),
+			MediaWikiServices::getDBLoadBalancer(),
 			$this->newLogger(),
 			'https://www.wikidata.org/w/api.php'
 		);

--- a/tests/integration/ApiEntityLookupIntegrationTest.php
+++ b/tests/integration/ApiEntityLookupIntegrationTest.php
@@ -37,7 +37,7 @@ class ApiEntityLookupIntegrationTest extends \PHPUnit_Framework_TestCase {
 	private function getApiEntityLookup() {
 		$entityImporterFactory = new EntityImporterFactory(
 			WikibaseRepo::getDefaultInstance()->getStore()->getEntityStore(),
-			MediaWikiServices::getDBLoadBalancer(),
+			MediaWikiServices::getInstance()->getDBLoadBalancer(),
 			$this->newLogger(),
 			'https://www.wikidata.org/w/api.php'
 		);

--- a/tests/integration/ApiEntityLookupIntegrationTest.php
+++ b/tests/integration/ApiEntityLookupIntegrationTest.php
@@ -8,6 +8,7 @@ use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\Import\EntityImporterFactory;
 use Wikibase\Repo\WikibaseRepo;
+use MediaWiki\MediaWikiServices;
 
 /**
  * @group WikibaseImport

--- a/tests/integration/EntityImporterFactoryTest.php
+++ b/tests/integration/EntityImporterFactoryTest.php
@@ -7,6 +7,7 @@ use Monolog\Handler\NullHandler;
 use Wikibase\Import\EntityImporter;
 use Wikibase\Import\EntityImporterFactory;
 use Wikibase\Repo\WikibaseRepo;
+use MediaWiki\MediaWikiServices;
 
 /**
  * @group WikibaseImport

--- a/tests/integration/EntityImporterFactoryTest.php
+++ b/tests/integration/EntityImporterFactoryTest.php
@@ -33,7 +33,7 @@ class EntityImporterFactoryTest extends \PHPUnit_Framework_TestCase {
 	private function newEntityImporterFactory() {
 		return new EntityImporterFactory(
 			WikibaseRepo::getDefaultInstance()->getStore()->getEntityStore(),
-			MediaWikiServices::getDBLoadBalancer(),
+			MediaWikiServices::getInstance()->getDBLoadBalancer(),
 			$this->newLogger(),
 			'https://www.wikidata.org/w/api.php'
 		);

--- a/tests/integration/EntityImporterFactoryTest.php
+++ b/tests/integration/EntityImporterFactoryTest.php
@@ -32,7 +32,7 @@ class EntityImporterFactoryTest extends \PHPUnit_Framework_TestCase {
 	private function newEntityImporterFactory() {
 		return new EntityImporterFactory(
 			WikibaseRepo::getDefaultInstance()->getStore()->getEntityStore(),
-			wfGetLB(),
+			MediaWikiServices::getDBLoadBalancer(),
 			$this->newLogger(),
 			'https://www.wikidata.org/w/api.php'
 		);

--- a/tests/integration/Store/DBImportedEntityMappingStoreTest.php
+++ b/tests/integration/Store/DBImportedEntityMappingStoreTest.php
@@ -45,7 +45,7 @@ class DBImportedEntityMappingStoreTest extends \MediaWikiTestCase {
 
 	private function newDBImportedEntityMappingStore() {
 		return new DBImportedEntityMappingStore(
-			wfGetLB(),
+			MediaWikiServices::getDBLoadBalancer(),
 			new BasicEntityIdParser()
 		);
 	}

--- a/tests/integration/Store/DBImportedEntityMappingStoreTest.php
+++ b/tests/integration/Store/DBImportedEntityMappingStoreTest.php
@@ -6,6 +6,7 @@ use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\Import\Store\DBImportedEntityMappingStore;
+use MediaWiki\MediaWikiServices;
 
 /**
  * @group WikibaseImport

--- a/tests/integration/Store/DBImportedEntityMappingStoreTest.php
+++ b/tests/integration/Store/DBImportedEntityMappingStoreTest.php
@@ -46,7 +46,7 @@ class DBImportedEntityMappingStoreTest extends \MediaWikiTestCase {
 
 	private function newDBImportedEntityMappingStore() {
 		return new DBImportedEntityMappingStore(
-			MediaWikiServices::getDBLoadBalancer(),
+			MediaWikiServices::getInstance()->getDBLoadBalancer(),
 			new BasicEntityIdParser()
 		);
 	}


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Just substitute wfGetLB() for MediaWikiServices::getInstance()->getDBLoadBalancer() when necessary (https://github.com/MaRDI4NFDI/WikibaseImport/issues/2)

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
